### PR TITLE
Mgdiagnosticto law

### DIFF
--- a/infra-as-code/bicep/modules/logging/modules/diagSettings.bicep
+++ b/infra-as-code/bicep/modules/logging/modules/diagSettings.bicep
@@ -1,0 +1,20 @@
+targetScope = 'managementGroup'
+
+param parLawId string
+
+resource mgDiagSet 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'toLa'
+  properties: {
+    workspaceId: parLawId
+    logs: [
+      {
+        category: 'Administrative'
+        enabled: true
+      }
+      {
+        category: 'Policy'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/infra-as-code/bicep/orchestration/mgDiagSet/bicepconfig.json
+++ b/infra-as-code/bicep/orchestration/mgDiagSet/bicepconfig.json
@@ -1,0 +1,64 @@
+{
+  "analyzers": {
+    "core": {
+      "enabled": true,
+      "verbose": true,
+      "rules": {
+        "adminusername-should-not-be-literal": {
+          "level": "error"
+        },
+        "no-hardcoded-env-urls": {
+          "level": "error"
+        },
+        "no-unnecessary-dependson": {
+          "level": "error"
+        },
+        "no-unused-params": {
+          "level": "error"
+        },
+        "no-unused-vars": {
+          "level": "error"
+        },
+        "outputs-should-not-contain-secrets": {
+          "level": "error"
+        },
+        "prefer-interpolation": {
+          "level": "error"
+        },
+        "secure-parameter-default": {
+          "level": "error"
+        },
+        "simplify-interpolation": {
+          "level": "error"
+        },
+        "protect-commandtoexecute-secrets": {
+          "level": "error"
+        },
+        "use-stable-vm-image": {
+          "level": "error"
+        },
+        "explicit-values-for-loc-params": {
+          "level": "error"
+        },
+        "no-hardcoded-location": {
+          "level": "error"
+        },
+        "no-loc-expr-outside-params": {
+          "level": "error"
+        },
+        "max-outputs": {
+          "level": "error"
+        },
+        "max-params": {
+          "level": "error"
+        },
+        "max-resources": {
+          "level": "error"
+        },
+        "max-variables": {
+          "level": "error"
+        }
+      }
+    }
+  }
+}

--- a/infra-as-code/bicep/orchestration/mgDiagSet/mgDiagSettings.bicep
+++ b/infra-as-code/bicep/orchestration/mgDiagSet/mgDiagSettings.bicep
@@ -26,10 +26,6 @@ var varMgIds = {
   sandbox: '${parTopLevelManagementGroupPrefix}-sandbox'
 }
 
-//var varMgChildIds = [for childMg in items(parLandingZoneMgChildren): {
-//  key: childMg
-//}]
-
 module modMgDiagSet './modules/diagSettings.bicep' = [for mgId in items(varMgIds): {
   scope: managementGroup(mgId.value)
   name: 'mg-diag-set-${mgId.key}'
@@ -46,5 +42,3 @@ module modLandingZonesMgChildrenDiagSet './modules/diagSettings.bicep' = [for ch
     parLawId: parLawId
   }
 }]
-
-output mgIDs object = varMgIds

--- a/infra-as-code/bicep/orchestration/mgDiagSet/mgDiagSettings.bicep
+++ b/infra-as-code/bicep/orchestration/mgDiagSet/mgDiagSettings.bicep
@@ -1,0 +1,50 @@
+targetScope = 'tenant'
+
+@description('Prefix used for the management group hierarchy in the managementGroups module.')
+@minLength(2)
+@maxLength(10)
+param parTopLevelManagementGroupPrefix string = 'alz'
+
+@description('Dictionary Object to allow additional or different child Management Groups of the Landing Zones Management Group .')
+param parLandingZoneMgChildren array = []
+
+@description('Log Analytics Workspace Id')
+param parLawId string
+
+var varMgIds = {
+  intRoot: parTopLevelManagementGroupPrefix
+  platform: '${parTopLevelManagementGroupPrefix}-platform'
+  platformManagement: '${parTopLevelManagementGroupPrefix}-platform-management'
+  platformConnectivity: '${parTopLevelManagementGroupPrefix}-platform-connectivity'
+  platformIdentity: '${parTopLevelManagementGroupPrefix}-platform-identity'
+  landingZones: '${parTopLevelManagementGroupPrefix}-landingzones'
+  landingZonesCorp: '${parTopLevelManagementGroupPrefix}-landingzones-corp'
+  landingZonesOnline: '${parTopLevelManagementGroupPrefix}-landingzones-online'
+  landingZonesConfidentialCorp: '${parTopLevelManagementGroupPrefix}-landingzones-confidential-corp'
+  landingZonesConfidentialOnline: '${parTopLevelManagementGroupPrefix}-landingzones-confidential-online'
+  decommissioned: '${parTopLevelManagementGroupPrefix}-decommissioned'
+  sandbox: '${parTopLevelManagementGroupPrefix}-sandbox'
+}
+
+//var varMgChildIds = [for childMg in items(parLandingZoneMgChildren): {
+//  key: childMg
+//}]
+
+module modMgDiagSet './modules/diagSettings.bicep' = [for mgId in items(varMgIds): {
+  scope: managementGroup(mgId.value)
+  name: 'mg-diag-set-${mgId.key}'
+  params: {
+    parLawId: parLawId
+  }
+}]
+
+// Custom Children Landing Zone Management Groups
+module modLandingZonesMgChildrenDiagSet './modules/diagSettings.bicep' = [for childMg in (parLandingZoneMgChildren): {
+  scope: managementGroup(childMg)
+  name: 'mg-diag-set-${childMg}'
+  params: {
+    parLawId: parLawId
+  }
+}]
+
+output mgIDs object = varMgIds

--- a/infra-as-code/bicep/orchestration/mgDiagSet/modules/diagSettings.bicep
+++ b/infra-as-code/bicep/orchestration/mgDiagSet/modules/diagSettings.bicep
@@ -1,0 +1,20 @@
+targetScope = 'managementGroup'
+
+param parLawId string
+
+resource mgDiagSet 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'toLa'
+  properties: {
+    workspaceId: parLawId
+    logs: [
+      {
+        category: 'Administrative'
+        enabled: true
+      }
+      {
+        category: 'Policy'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/infra-as-code/bicep/orchestration/mgDiagSet/parameters/mgDiagSet.parameters.all.json
+++ b/infra-as-code/bicep/orchestration/mgDiagSet/parameters/mgDiagSet.parameters.all.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "parTopLevelManagementGroupPrefix": {
+      "value": "alz"
+    },
+    "parLawId": {
+        "value": "/subscriptions/ce14dde3-0f98-4198-ae91-260a4a83d62b/resourcegroups/alz-logging/providers/microsoft.operationalinsights/workspaces/alz-log-analytics"
+    },
+     "parLandingZoneMgChildren": {
+      "value": [
+        "alz-landingzones-SAP",
+        "alz-landingzones-AVS"
+      ]
+    }
+}
+}

--- a/infra-as-code/bicep/orchestration/mgDiagSet/parameters/mgDiagSet.parameters.min.json
+++ b/infra-as-code/bicep/orchestration/mgDiagSet/parameters/mgDiagSet.parameters.min.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "parTopLevelManagementGroupPrefix": {
+      "value": "alz"
+    },
+    "parLawId": {
+        "value": ""
+    }
+}


### PR DESCRIPTION
# Overview/Summary

Added module to enable Diagnostics Settings for Management Groups

## This PR adds

1. a Bicep module under orchestration folder to enable Diagnostic Settings to Management Groups created during the managementGroup module. 

### Breaking Changes
None

## Testing Evidence

Tested with REST API to confirm correct enablement of diagnostic settings. 

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/ALZ-Bicep/wiki/Contributing) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/ALZ-Bicep/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/ALZ-Bicep/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/ALZ-Bicep/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated one or more of the following tests *(if required)*
  - [Unit](https://github.com/Azure/ALZ-Bicep/blob/main/.github/workflows/bicep-build-to-validate.yml)
  - [Linting](https://github.com/Azure/ALZ-Bicep/tree/main/.github/workflows)
  - [E2E (End-To-End)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/bicep-build-to-validate.yml)
  - [ValidateAzCloud (Base validation in Azure Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/base-unit-validate.yml)
  - [ValidateMcCloud (Base validation in Azure China Cloud)](https://github.com/Azure/ALZ-Bicep/blob/main/tests/pipelines/mc-base-unit-validate.yml)
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Wiki Docs etc.)
- [ ] If relevant, created or updated Code Tours [here](https://github.com/Azure/ALZ-Bicep/blob/main/.vscode/tours)
